### PR TITLE
Add web middleware as default

### DIFF
--- a/src/LoginLinkServiceProvider.php
+++ b/src/LoginLinkServiceProvider.php
@@ -26,6 +26,6 @@ class LoginLinkServiceProvider extends PackageServiceProvider
 
         Route::post('laravel-login-link-login', $controller)
             ->name('loginLinkLogin')
-            ->middleware(config('login-link.middleware'));
+            ->middleware(config('login-link.middleware', ['web']));
     }
 }


### PR DESCRIPTION
As mentioned in discussion #2, this currently only seems to work with the config file published.

Looked into it, and it's breaking because without the config file present it doesn't use the web middleware which stops it authenticating properly. 

This just sets web as the default when no config is present, you can still customise/remove it with the config should you need to.