### PR TITLE
Update reference of "id" attribute to "key" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The package will log in the first user in the table. You customize that by passi
 Alternatively, you can specify the primary key of the user (in most cases this will be the `id`)
 
 ```blade
-<x-login-link id="123"  />
+<x-login-link key="123"  />
 ```
 
 You can also specify the attributes of the user that needs to be logged in.


### PR DESCRIPTION
The blade component wants a "key" attribute rather than the "id" that's specified in the README.
This change updates the README to reflect that.