### PR TITLE
Allow to override user creation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ return [
     'login_link_controller' => LoginLinkController::class,
 
     /*
+     * The action class to use to create a new user.
+     * 
+     * Should implement \Spatie\LoginLink\Actions\CreateUserActionInterface
+     */
+    'create_user_action' => CreateUserAction::class,
+
+    /*
      * This middleware will be applied on the route
      * that logs in a user via a link.
      */
@@ -172,6 +179,8 @@ By default, the package will use the default guard. You can specify another guar
 If the user that needs to be logged in does not exist, the package will use the factory of your user model to create the user, and log that new user in.
 
 If you don't want this behaviour, set `automatically_create_missing_users` in the `local-link` config file to `false`.
+
+You can customize how the user is created by providing a custom action through the `create_user_action` configuration value.
 
 ### Usage with Vue / React / ...
 

--- a/config/login-link.php
+++ b/config/login-link.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\LoginLink\Actions\CreateUserAction;
 use Spatie\LoginLink\Http\Controllers\LoginLinkController;
 
 return [
@@ -35,6 +36,13 @@ return [
      * override this class.
      */
     'login_link_controller' => LoginLinkController::class,
+
+    /*
+     * The action class to use to create a new user.
+     *
+     * Should implement \Spatie\LoginLink\Actions\CreateUserActionInterface
+     */
+    'create_user_action' => CreateUserAction::class,
 
     /*
      * This middleware will be applied on the route

--- a/src/Actions/CreateUserAction.php
+++ b/src/Actions/CreateUserAction.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LoginLink\Actions;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class CreateUserAction implements CreateUserActionInterface
+{
+    public function execute(string $authenticatableClass, array $attributes): Authenticatable
+    {
+        return $authenticatableClass::factory()->create($attributes);
+    }
+}

--- a/src/Actions/CreateUserActionInterface.php
+++ b/src/Actions/CreateUserActionInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\LoginLink\Actions;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+
+interface CreateUserActionInterface
+{
+    public function execute(string $authenticatableClass, array $attributes): Authenticatable;
+}

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -4,6 +4,8 @@ namespace Spatie\LoginLink\Http\Controllers;
 
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Builder;
+use Spatie\LoginLink\Actions\CreateUserAction;
+use Spatie\LoginLink\Actions\CreateUserActionInterface;
 use Spatie\LoginLink\Exceptions\DidNotFindUserToLogIn;
 use Spatie\LoginLink\Exceptions\InvalidUserClass;
 use Spatie\LoginLink\Exceptions\NotAllowedInCurrentEnvironment;
@@ -106,7 +108,10 @@ class LoginLinkController
 
     protected function createUser(string $authenticatableClass, array $attributes): Authenticatable
     {
-        return $authenticatableClass::factory()->create($attributes);
+        /** @var CreateUserActionInterface $createUserClass */
+        $createUserClass = app(config('login-link.create_user_action', CreateUserAction::class));
+
+        return $createUserClass->execute($authenticatableClass, $attributes);
     }
 
     protected function getRedirectUrl(LoginLinkRequest $request): string

--- a/tests/LoginLinkControllerTest.php
+++ b/tests/LoginLinkControllerTest.php
@@ -2,6 +2,8 @@
 
 use function Pest\Laravel\post;
 
+use Spatie\LoginLink\Tests\TestSupport\Actions\TestCreateUserAction;
+
 use Spatie\LoginLink\Tests\TestSupport\Models\Admin;
 use Spatie\LoginLink\Tests\TestSupport\Models\User;
 
@@ -158,4 +160,14 @@ it('will throw an exception when no user class can be determined', function () {
     config()->set('auth.providers.users.model', null);
 
     post(route('loginLinkLogin'))->assertStatus(500);
+});
+
+it('accepts a custom create user action', function () {
+    config()->set('login-link.create_user_action', TestCreateUserAction::class);
+
+    post(route('loginLinkLogin'))->assertRedirect();
+
+    expectUserToBeLoggedIn([
+        'email' => TestCreateUserAction::EMAIL,
+    ]);
 });

--- a/tests/TestSupport/Actions/TestCreateUserAction.php
+++ b/tests/TestSupport/Actions/TestCreateUserAction.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\LoginLink\Tests\TestSupport\Actions;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Spatie\LoginLink\Actions\CreateUserActionInterface;
+
+class TestCreateUserAction implements CreateUserActionInterface
+{
+    public const EMAIL = 'custom-action@spatie.be';
+
+    public function execute(string $authenticatableClass, array $attributes): Authenticatable
+    {
+        return (new $authenticatableClass())->forceFill([...$attributes, 'email' => self::EMAIL]);
+    }
+}


### PR DESCRIPTION
This allows the user to override the logic how a user is created. It vendors a default action that does exactly the same as the package used to do before.

I am using this package with Jetstream and found myself wanting to change the logic so that teams are created alongside, this will enable users to do so while keeping it completely backwards compatible.