### PR TITLE
Add verification of allowed hosts in login-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ In your login view, you can add the `x-login-link` component to show the login l
 @endenv
 ```
 
+By default, only localhost is allowed. If you want to allow other hosts, you can add them to the `allowed_hosts` config key.
+
+```php
+'allowed_hosts' => [
+    'localhost',
+    'example.com',
+],
+```
+
 Here's what that might look like in the browser:
 
 <img style="width: 500px" alt="screenshot" src="https://github.com/spatie/laravel-login-link/blob/main/docs/login.png?raw=true" />
@@ -40,7 +49,7 @@ We highly appreciate you sending us a postcard from your hometown, mentioning wh
 
 ## Installation
 
-You can install the package via composer. 
+You can install the package via composer.
 
 ```bash
 composer require spatie/laravel-login-link
@@ -63,6 +72,12 @@ return [
      * other environments, an exception will be thrown.
      */
     'allowed_environments' => ['local'],
+
+    /*
+     * Login links will only work in these hosts. In all
+     * other hosts, an exception will be thrown.
+     */
+    'allowed_hosts' => ['localhost'],
 
     /*
      * The package will automatically create a user model when trying
@@ -115,7 +130,7 @@ To render a login link, simply add the `x-login-link` Blade component to your vi
 @endenv
 ```
 
-This component will render a link that, when clicked, will log you in. By default, it will 
+This component will render a link that, when clicked, will log you in. By default, it will
 redirect you to the last intended/requested url, but you can customize that by specifying a route name in the `redirect_route_name` of the `login-link` config file.
 You can also specify the redirect URL on the component itself:
 
@@ -244,6 +259,12 @@ Since this is a POST request, make sure to pass a CSRF token as well.
 Out of the box, the login link will only work in a local environment. If you want to use it other environments, set the `allowed_environments` key of the `login-link` config file to the names of those environments.
 
 Beware however, that you should never display login links in any environment that is publicly reachable, as it will allow anyone to log in.
+
+### Usage on other hosts
+
+Out of the box, the login link will only work on localhost. If you want to use it on other hosts, set the `allowed_hosts` key of the `login-link` config file to the names of those hosts.
+
+Note, however, that you should never display login links on any host that is publicly reachable, as it will allow anyone to log in.
 
 ## How the package works under the hood
 

--- a/config/login-link.php
+++ b/config/login-link.php
@@ -10,6 +10,12 @@ return [
     'allowed_environments' => ['local'],
 
     /*
+     * Login links will only work in these hosts. In all
+     * other hosts, an exception will be thrown.
+     */
+    'allowed_hosts' => ['localhost'],
+
+    /*
      * The package will automatically create a user model when trying
      * to log in a user that doesn't exist.
      */

--- a/src/Exceptions/NotAllowedInCurrentHost.php
+++ b/src/Exceptions/NotAllowedInCurrentHost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\LoginLink\Exceptions;
+
+use Exception;
+
+class NotAllowedInCurrentHost extends Exception
+{
+    public static function make(string $currentHost, array $allowedHosts): self
+    {
+        $allowedHosts = collect($allowedHosts)
+            ->map(fn (string $host) => "`{$host}`")
+            ->join(', ', ' and');
+
+        return new self("You can not use a login link when host is `{$currentHost}`. The host should be one of: {$allowedHosts}.");
+    }
+}

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\LoginLink\Exceptions\DidNotFindUserToLogIn;
 use Spatie\LoginLink\Exceptions\InvalidUserClass;
 use Spatie\LoginLink\Exceptions\NotAllowedInCurrentEnvironment;
+use Spatie\LoginLink\Exceptions\NotAllowedInCurrentHost;
 use Spatie\LoginLink\Http\Requests\LoginLinkRequest;
 
 class LoginLinkController
@@ -14,6 +15,8 @@ class LoginLinkController
     public function __invoke(LoginLinkRequest $request)
     {
         $this->ensureAllowedEnvironment();
+
+        $this->ensureAllowedHost($request);
 
         $authenticatable = $this->getAuthenticatable($request);
 
@@ -30,6 +33,16 @@ class LoginLinkController
 
         if (! app()->environment($allowedEnvironments)) {
             throw NotAllowedInCurrentEnvironment::make($allowedEnvironments);
+        }
+    }
+
+    protected function ensureAllowedHost(LoginLinkRequest $request): void
+    {
+        $allowedHosts = config('login-link.allowed_hosts');
+        $currentHost = $request->getHost();
+
+        if (! in_array($currentHost, $allowedHosts)) {
+            throw NotAllowedInCurrentHost::make($currentHost, $allowedHosts);
         }
     }
 

--- a/tests/LoginLinkControllerTest.php
+++ b/tests/LoginLinkControllerTest.php
@@ -153,6 +153,14 @@ it('will not work in the wrong environment', function () {
     expect(auth()->check())->toBeFalse();
 });
 
+it('will not work on wrong host', function () {
+    config()->set('login-link.allowed_hosts', ['testing-host']);
+
+    post(route('loginLinkLogin'))->assertStatus(500);
+
+    expect(auth()->check())->toBeFalse();
+});
+
 it('will throw an exception when no user class can be determined', function () {
     config()->set('login-link.user_model', null);
     config()->set('auth.providers.users.model', null);


### PR DESCRIPTION
Originally, this package was designed to be installed only in composer dev. The problem was that in that case it throws an exception when compiling the blade `x-login-link` component, so that recommendation was removed from the README.

This pull request proposes to add the `allowed_hosts` configuration with the default value `localhost` to avoid security issues with the default configuration, as explained in discussion #41.

The blade template has not been modified intentionally, to keep a clean installation of the package. If someone uses it and has a host other than `localhost`, they will see the `NotAllowedInCurrentHost` exception indicating the reason.

