### PR TITLE
Fix null handling in LoginLinkRequest userAttributes

### DIFF
--- a/src/Http/Requests/LoginLinkRequest.php
+++ b/src/Http/Requests/LoginLinkRequest.php
@@ -19,6 +19,10 @@ class LoginLinkRequest extends FormRequest
 
     public function userAttributes(): array
     {
-        return json_decode($this->user_attributes, true) ?? [];
+        if ($this->user_attributes !== null) {
+            return json_decode($this->user_attributes);
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
Fixes a deprecation:

<img width="715" alt="Capture d’écran 2024-12-13 à 08 45 33" src="https://github.com/user-attachments/assets/a0293575-aadc-4176-b6c9-017ef06d73ae" />
