### PR TITLE
Add support for using a custom user model 

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,18 @@ By default, the package will use the default guard. You can specify another guar
 <x-login-link guard="admin">
 ```
 
+### Using custom user model to log in
+
+You can specify the user model to log in by passing the `user_model` attribute to the component.
+
+The user model should implement the `Illuminate\Contracts\Auth\Authenticatable` interface.
+
+Using the `user_model` will use `null` as default for the `guard` attribute.
+
+```blade
+<x-login-link user_model="App\\Models\\Customer" email="customer@spatie.be">
+```
+
 ### Automatic user creation
 
 If the user that needs to be logged in does not exist, the package will use the factory of your user model to create the user, and log that new user in.

--- a/resources/views/loginLink.blade.php
+++ b/resources/views/loginLink.blade.php
@@ -7,6 +7,7 @@
         <input type="hidden" name="redirect_url" value="{{ $redirectUrl }}">
         <input type="hidden" name="guard" value="{{ $guard }}">
         <input type="hidden" name="user_attributes" value="{{ json_encode($userAttributes) }}">
+        <input type="hidden" name="user_model" value="{{ $userModel }}">
 
         @include('login-link::loginLinkButton')
     </form>

--- a/src/Http/Components/LoginLinkComponent.php
+++ b/src/Http/Components/LoginLinkComponent.php
@@ -13,6 +13,7 @@ class LoginLinkComponent extends Component
         public string $label = 'Developer Login',
         public ?string $redirectUrl = null,
         public ?string $guard = null,
+        public ?string $userModel = null,
     ) {
     }
 

--- a/src/Http/Requests/LoginLinkRequest.php
+++ b/src/Http/Requests/LoginLinkRequest.php
@@ -14,6 +14,7 @@ class LoginLinkRequest extends FormRequest
             'user_attributes' => '',
             'redirect_url' => '',
             'guard' => '',
+            'user_model' => '',
         ];
     }
 

--- a/tests/LoginLinkComponentTest.php
+++ b/tests/LoginLinkComponentTest.php
@@ -56,6 +56,12 @@ it('can render a login link with a specific guard', function () {
     assertMatchesHtmlSnapshot($html);
 });
 
+it('can render a login link with a custom user model', function () {
+    $html = Blade::render('<x-login-link user_model="App\\Models\\Customer" />');
+
+    assertMatchesHtmlSnapshot($html);
+});
+
 it('can render a login link with specific css classes', function () {
     $html = Blade::render('<x-login-link class="text-red-500" />');
 

--- a/tests/LoginLinkControllerTest.php
+++ b/tests/LoginLinkControllerTest.php
@@ -4,6 +4,7 @@ use function Pest\Laravel\post;
 
 use Spatie\LoginLink\Tests\TestSupport\Models\Admin;
 use Spatie\LoginLink\Tests\TestSupport\Models\User;
+use Spatie\LoginLink\Tests\TestSupport\Models\Customer;
 
 it('will create and login a user', function () {
     post(route('loginLinkLogin'))->assertRedirect();
@@ -120,6 +121,28 @@ it('can create a user with both email and custom attributes', function () {
         'email' => 'freek@spatie.be',
         'role' => 'admin',
     ]);
+});
+
+it('can login an existing custom model with a specific email', function () {
+    Customer::factory()->create(['email' => 'customer@spatie.be']);
+    $data = ['email' => 'customer@spatie.be', 'user_model' => Customer::class];
+
+    post(route('loginLinkLogin'), $data)->assertRedirect();
+
+    expectUserToBeLoggedIn(['email' => 'customer@spatie.be']);
+    expect(Customer::count())->toBe(1);
+});
+
+it('can create and login a custom model with specific attributes', function () {
+    $data = [
+        'user_attributes' => json_encode(['email' => 'customer@spatie.be']),
+        'user_model' => Customer::class
+    ];
+
+    post(route('loginLinkLogin'), $data)->assertRedirect();
+
+    expectUserToBeLoggedIn(['email' => 'customer@spatie.be']);
+    expect(Customer::count())->toBe(1);
 });
 
 it('can redirect to a specific url', function () {

--- a/tests/TestSupport/Database/Factories/CustomerFactory.php
+++ b/tests/TestSupport/Database/Factories/CustomerFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\LoginLink\Tests\TestSupport\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Spatie\LoginLink\Tests\TestSupport\Models\Customer;
+
+class CustomerFactory extends Factory
+{
+    protected $model = Customer::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => bcrypt('secret'),
+        ];
+    }
+}

--- a/tests/TestSupport/Models/Customer.php
+++ b/tests/TestSupport/Models/Customer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\LoginLink\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as IlluminateUser;
+
+class Customer extends IlluminateUser
+{
+    protected $table = 'customers';
+
+    use HasFactory;
+}

--- a/tests/TestSupport/TestCase.php
+++ b/tests/TestSupport/TestCase.php
@@ -64,6 +64,15 @@ class TestCase extends Orchestra
             $table->timestamps();
         });
 
+        Schema::create('customers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('password');
+
+            $table->timestamps();
+        });
+
         return $this;
     }
 

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_email__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_email__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_key__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_key__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_label__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_label__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     My label

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_user_model__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_custom_user_model__1.html
@@ -3,10 +3,10 @@
         <input type="hidden" name="_token" value="" autocomplete="off">
         <input type="hidden" name="email" value="">
         <input type="hidden" name="key" value="">
-        <input type="hidden" name="redirect_url" value="http://localhost/custom-url">
+        <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
-        <input type="hidden" name="user_model" value="">
+        <input type="hidden" name="user_model" value="App\Models\Customer">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_specific_guard__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_a_specific_guard__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="admin">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_custom_user_attributes__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_custom_user_attributes__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value='{"role":"admin"}'>
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_custom_user_attributes_with_a_space_from_a_variable__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_custom_user_attributes_with_a_space_from_a_variable__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value='{"role":"senior admin"}'>
+        <input type="hidden" name="user_model" value="">
 
         <button class="underline" type="submit">
     Developer Login

--- a/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_specific_css_classes__1.html
+++ b/tests/__snapshots__/LoginLinkComponentTest__it_can_render_a_login_link_with_specific_css_classes__1.html
@@ -6,6 +6,7 @@
         <input type="hidden" name="redirect_url" value="">
         <input type="hidden" name="guard" value="">
         <input type="hidden" name="user_attributes" value="[]">
+        <input type="hidden" name="user_model" value="">
 
         <button class="text-red-500" type="submit">
     Developer Login


### PR DESCRIPTION
This PR makes it possible to dynamically use a custom model to login without using the `guard`

**Usage:**
```blade
<x-login-link user-model="App\\Models\\Customer" email="customer@spatie.be" label="Login as Customer"/>
```
