### PR TITLE
make allowed hosts backward compatible checking user config

### DIFF
--- a/config/login-link.php
+++ b/config/login-link.php
@@ -13,7 +13,10 @@ return [
      * Login links will only work in these hosts. In all
      * other hosts, an exception will be thrown.
      */
-    'allowed_hosts' => ['localhost'],
+    'allowed_hosts' => [
+        'localhost',
+        '127.0.0.1',
+    ],
 
     /*
      * The package will automatically create a user model when trying

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -141,7 +141,7 @@ class LoginLinkController
         return redirect()->intended()->getTargetUrl();
     }
 
-    private function getUserConfig($key)
+    protected function getUserConfig($key)
     {
         $parts = explode('.', $key);
 

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -39,7 +39,7 @@ class LoginLinkController
 
     protected function ensureAllowedHost(LoginLinkRequest $request): void
     {
-        if ($this->getLocalConfig('login-link.allowed_hosts') === null) {
+        if ($this->getUserConfig('login-link.allowed_hosts') === null) {
             return;
         }
 
@@ -141,7 +141,7 @@ class LoginLinkController
         return redirect()->intended()->getTargetUrl();
     }
 
-    private function getLocalConfig($key)
+    private function getUserConfig($key)
     {
         $parts = explode('.', $key);
 

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -155,6 +155,6 @@ class LoginLinkController
 
         $configuration = require $configPath;
 
-        return Arr::get($configuration, implode('.', $parts), $default);
+        return Arr::get($configuration, $key);
     }
 }


### PR DESCRIPTION
Hi,

I have seen version 1.5.1 trying to make the `allowed_hosts` backwards compatible. Unfortunately, this change does not work, because the `config('login-link.allowed_hosts')` will merge the user configuration and the package configuration, so if the user does not have the configuration set, this helper will return the package configuration making this check useless.

I have added a private method to get the user configuration first, and if it is not set, then it will not throw the exception, keeping the original idea of making it backwards compatible, although I still think it is a bad idea and it would be better to throw the exception.

I have also added 127.0.0.1 to the default list of allowed hosts.

I haven't added tests because I don't know how to fake the user configuration and the package configuration separately. I noticed the problem while checking your PR in my local environment.