### PR TITLE
Fix ensure allowed host

### DIFF
--- a/src/Exceptions/NotAllowedInCurrentEnvironment.php
+++ b/src/Exceptions/NotAllowedInCurrentEnvironment.php
@@ -12,7 +12,7 @@ class NotAllowedInCurrentEnvironment extends Exception
 
         $allowedEnvironments = collect($allowedEnvironments)
             ->map(fn (string $environment) => "`{$environment}`")
-            ->join(', ', ' and');
+            ->join(', ', ' and ');
 
         return new self("You can not use a login link when environment is set to `{$currentEnvironment}`. The environment should be one of: {$allowedEnvironments}.");
     }

--- a/src/Exceptions/NotAllowedInCurrentHost.php
+++ b/src/Exceptions/NotAllowedInCurrentHost.php
@@ -10,7 +10,7 @@ class NotAllowedInCurrentHost extends Exception
     {
         $allowedHosts = collect($allowedHosts)
             ->map(fn (string $host) => "`{$host}`")
-            ->join(', ', ' and');
+            ->join(', ', ' and ');
 
         return new self("You can not use a login link when host is `{$currentHost}`. The host should be one of: {$allowedHosts}.");
     }

--- a/src/Http/Controllers/LoginLinkController.php
+++ b/src/Http/Controllers/LoginLinkController.php
@@ -39,7 +39,9 @@ class LoginLinkController
 
     protected function ensureAllowedHost(LoginLinkRequest $request): void
     {
-        if ($this->getUserConfig('login-link.allowed_hosts') === null) {
+        $config = config('login-link');
+
+        if (! isset($config['allowed_hosts'])) {
             return;
         }
 
@@ -156,22 +158,5 @@ class LoginLinkController
         }
 
         return null;
-    }
-
-    protected function getUserConfig($key)
-    {
-        $parts = explode('.', $key);
-
-        $file = array_shift($parts);
-
-        $configPath = config_path($file.'.php');
-
-        if (! file_exists($configPath)) {
-            return config($key);
-        }
-
-        $configuration = require $configPath;
-
-        return Arr::get($configuration, $key);
     }
 }


### PR DESCRIPTION
Fix an issue with `ensureAllowedHost` ignoring `allowed_hosts` when `login-link `config is published.

The `getUserConfig` function was always returning `null` if when the config file exists as `Arr::get` will never match `$key` with `$configuration`. Best to rely on Laravel's built-in config helper.

Also updated exceptions messages when joining strings.